### PR TITLE
Some Changes

### DIFF
--- a/config/aobd.cfg
+++ b/config/aobd.cfg
@@ -133,7 +133,7 @@ Cobalt {
 
 
 Cobaltum {
-    B:"Disable All"=false
+    B:"Disable All"=true
     B:Eln=true
     B:EnderIO=true
     B:HydCraft=true
@@ -1023,7 +1023,7 @@ Tungsten {
 
 
 Wolframium {
-    B:"Disable All"=false
+    B:"Disable All"=true
     B:Eln=true
     B:EnderIO=true
     B:HydCraft=true

--- a/config/customthings/lang/en_US.lang
+++ b/config/customthings/lang/en_US.lang
@@ -1,4 +1,4 @@
-item.customthings.sparkpowder.name=Sparkpowder
+item.sparkpowder.name=Sparkpowder
 tile.customthings.ore.nether.iron.name=Nether Iron Ore
 tile.customthings.ore.nether.gold.name=Nether Gold Ore
 tile.customthings.ore.nether.redstone.name=Nether Redstone Ore

--- a/scripts/Aether.zs
+++ b/scripts/Aether.zs
@@ -1,0 +1,38 @@
+/* Aether
+   Tweaks and Alterations */
+
+//Adding Berries to oredict
+<ore:foodBerries>.add(<aether:blueBerry>);
+<ore:foodBerries>.add(<aether:enchantedBerry>);
+<ore:foodBerries>.add(<aether:rainbowStrawberry>);
+<ore:foodBerries>.add(<aether:wyndberry>);
+
+//Adding Oranges to oredict
+<ore:cropOrange>.add(<aether:orange>);
+
+//Adding Jelly to oredict
+<ore:foodJelly>.add(<aether:swetJelly:0>);
+<ore:foodJelly>.add(<aether:swetJelly:1>);
+<ore:foodJelly>.add(<aether:swetJelly:2>);
+
+//Crafting Aether food with other mods
+//Blueberry Lollipop
+recipes.addShapeless(<aether:blueberryLollipop>, [<plantmegapack:berriesBlue>, <minecraft:sugar>, <ore:stickWood>]);
+<plantmegapack:berriesBlue>.addTooltip(format.darkGray("Crafting: ") + format.blue("Blueberry Lollipop"));
+recipes.addShapeless(<aether:blueberryLollipop>, [<ExtraTrees:food:45>, <minecraft:sugar>, <ore:stickWood>]);
+//Orange Lollipop
+recipes.removeShapeless(<aether:orangeLollipop>);
+recipes.addShapeless(<aether:orangeLollipop>, [<ore:cropOrange>, <minecraft:sugar>, <aether:skyrootStick>]);
+recipes.addShapeless(<aether:orangeLollipop>, [<ore:cropOrange>, <minecraft:sugar>, <ore:stickWood>]);
+//Jelly Pumpkin
+recipes.removeShapeless(<aether:jellyPumpkin>);
+recipes.addShapeless(<aether:jellyPumpkin>, [<ore:cropOrange>, <ore:foodJelly>, <minecraft:sugar>]);
+
+//Crafing Plant Mega Pack food with Aether's blueberries
+//Muffin
+recipes.addShapeless(<plantmegapack:foodBlueberryMuffin> * 6, [<aether:blueBerry>, <aether:blueBerry>, <minecraft:bread>]);
+recipes.addShapeless(<plantmegapack:foodBlueberryMuffin> * 6, [<aether:blueBerry>, <aether:blueBerry>, <plantmegapack:foodCornBread>]);
+//Slushie
+recipes.addShaped(<plantmegapack:foodBlueberrySlushie>,  [[<aether:blueBerry>, <aether:blueBerry>, <aether:blueBerry>], [<minecraft:sugar>, <ore:bucketMilk>, <minecraft:sugar>], [null, <minecraft:glass_bottle>, null]]);
+
+

--- a/scripts/BOP.zs
+++ b/scripts/BOP.zs
@@ -70,3 +70,47 @@ mods.forestry.Squeezer.addRecipe(<liquid:poison> * 10, <Forestry:mulch> % 5,[<pl
 mods.forestry.Squeezer.addRecipe(<liquid:poison> * 10, <Forestry:mulch> % 5,[<plantmegapack:shrubDwarfElder>], 20);
 mods.forestry.Squeezer.addRecipe(<liquid:poison> * 10, <Forestry:mulch> % 5,[<plantmegapack:shrubSpicebush>], 20);
 
+//Poison extract Jar Filling
+mods.thermalexpansion.Transposer.addFillRecipe(2000, <BiomesOPlenty:jarEmpty>, <BiomesOPlenty:jarFilled:1>, <liquid:poison> * 40);
+mods.thermalexpansion.Transposer.addExtractRecipe(2000, <BiomesOPlenty:jarFilled:1>, <liquid:poison> * 40,  <BiomesOPlenty:jarEmpty>, 100);
+
+//Crafting Dart Blower with Bamboo
+recipes.addShaped(<BiomesOPlenty:dartBlower>, [[<tropicraft:bambooStick>, null, <tropicraft:bambooStick>], [<tropicraft:bambooStick>, null, <tropicraft:bambooStick>], [<tropicraft:bambooStick>, null, <tropicraft:bambooStick>]]);
+
+//Crafting Darts with Bamboo, feathers, and a knife
+recipes.addShaped(<BiomesOPlenty:dart> * 3, [[<tropicraft:bambooStick>, null], [<tropicraft:bambooStick>, <cfm:ItemKnife>.anyDamage().transformDamage(6)], [<minecraft:feather>, null]]);
+
+//Adding Berries to oredict
+<ore:foodBerries>.add(<BiomesOPlenty:food:0>);
+
+//Fruit Salad can be crafted with any Berry
+recipes.remove(<BiomesOPlenty:food:4>);
+recipes.addShapeless(<BiomesOPlenty:food:4>, [<minecraft:bowl>, <ore:foodBerries>, <minecraft:apple>, <minecraft:melon>]);
+
+//Amber Recipe removed (added to Chisel category, can be chiseled from TC Amber)
+recipes.remove(<BiomesOPlenty:gemOre:15>);
+
+//Leaf Pile Crafting
+recipes.addShaped(<BiomesOPlenty:foliage:14> * 3, [[<ore:treeLeaves>, <ore:treeLeaves>]]);
+//dead Leaf Pile Drying
+mods.tconstruct.Drying.addRecipe(<BiomesOPlenty:foliage:14>, <BiomesOPlenty:foliage:15>, 1000);
+
+//Lilly Varieties Crafting
+recipes.addShapeless(<BiomesOPlenty:lilyBop:1>, [<gendustry:MutagenBucket>, <ore:fertilizerRich>, <BiomesOPlenty:lilyBop:2>]);
+recipes.addShapeless(<BiomesOPlenty:lilyBop:0>, [<gendustry:MutagenBucket>, <ore:fertilizerRich>, <BiomesOPlenty:lilyBop:1>]);
+recipes.addShapeless(<minecraft:waterlily>, [<gendustry:MutagenBucket>, <ore:fertilizerRich>, <BiomesOPlenty:lilyBop:0>]);
+
+recipes.addShapeless(<BiomesOPlenty:lilyBop:2>, [<gendustry:MutagenBucket>, <Botany:misc:7>, <BiomesOPlenty:lilyBop:1>]);
+recipes.addShapeless(<BiomesOPlenty:lilyBop:1>, [<gendustry:MutagenBucket>, <Botany:misc:7>, <BiomesOPlenty:lilyBop>]);
+recipes.addShapeless(<BiomesOPlenty:lilyBop>, [<gendustry:MutagenBucket>, <Botany:misc:7>, <minecraft:waterlily>]);
+//Lilly production with photogenic insolator
+mods.thermalexpansion.Insolator.addRecipe(7200, <ThermalExpansion:material:516>, <BiomesOPlenty:lilyBop:1>, <BiomesOPlenty:lilyBop:0> * 2);
+mods.thermalexpansion.Insolator.addRecipe(9600, <ThermalExpansion:material:517>, <BiomesOPlenty:lilyBop:1>, <BiomesOPlenty:lilyBop:0> * 6);
+
+mods.thermalexpansion.Insolator.addRecipe(7200, <ThermalExpansion:material:516>, <BiomesOPlenty:lilyBop:1>, <BiomesOPlenty:lilyBop:1> * 2);
+mods.thermalexpansion.Insolator.addRecipe(9600, <ThermalExpansion:material:517>, <BiomesOPlenty:lilyBop:1>, <BiomesOPlenty:lilyBop:1> * 6);
+
+mods.thermalexpansion.Insolator.addRecipe(7200, <ThermalExpansion:material:516>, <BiomesOPlenty:lilyBop:1>, <BiomesOPlenty:lilyBop:2> * 2);
+mods.thermalexpansion.Insolator.addRecipe(9600, <ThermalExpansion:material:517>, <BiomesOPlenty:lilyBop:1>, <BiomesOPlenty:lilyBop:2> * 6);
+
+

--- a/scripts/Binnie.zs
+++ b/scripts/Binnie.zs
@@ -1,6 +1,15 @@
 /* Binnie's Mods
    Tweaks and Alterations */
 
+//Adding Berries to oredict
+<ore:foodBerries>.add(<ExtraTrees:food:34>);
+<ore:foodBerries>.add(<ExtraTrees:food:43>);
+<ore:foodBerries>.add(<ExtraTrees:food:44>);
+<ore:foodBerries>.add(<ExtraTrees:food:45>);
+<ore:foodBerries>.add(<ExtraTrees:food:46>);
+<ore:foodBerries>.add(<ExtraTrees:food:48>);
+<ore:foodBerries>.add(<ExtraTrees:food:49>);
+
 //Soil recipies
 
 recipes.addShapeless(<Botany:soil:3> * 4, [<Botany:soil:0>, <Botany:soil:0>, <Botany:soil:0>, <Botany:soil:0>, <BiomesOPlenty:misc:1>]);
@@ -30,6 +39,10 @@ recipes.addShapeless(<Botany:flowerbed:8> * 4, [<Botany:flowerbed:5>, <Botany:fl
 //Adding ash powder
 recipes.removeShapeless(<Botany:misc>);
 recipes.addShapeless(<Botany:misc> * 4, [<ore:dustAsh>]);
+
+//Adding wood pulp powder
+recipes.remove(<Botany:misc:1>);
+recipes.addShapeless(<Botany:misc:1> * 4, [<ore:pulpWood>]);
 
 /* Fences */
 

--- a/scripts/Chisel.zs
+++ b/scripts/Chisel.zs
@@ -83,3 +83,82 @@ mods.chisel.Groups.addVariation("granite", <Botania:stone:11>);
 
 // Uranium
 mods.chisel.Groups.addVariation("uraniumblock", <BigReactors:BRMetalBlock>);
+
+//Ice Stairs
+mods.chisel.Groups.addVariation("ice_stairs", <Railcraft:stair:4>);
+mods.chisel.Groups.addVariation("ice_stairs", <witchery:icestairs>);
+
+//Ruby Blocks
+mods.chisel.Groups.addGroup("ruby_block"); 
+mods.chisel.Groups.addVariation("ruby_block", <BiomesOPlenty:gemOre:3>);
+mods.chisel.Groups.addVariation("ruby_block", <bluepower:ruby_block>);
+
+//Sapphire Blocks
+mods.chisel.Groups.addGroup("sapphire_block"); 
+mods.chisel.Groups.addVariation("sapphire_block", <BiomesOPlenty:gemOre:13>);
+mods.chisel.Groups.addVariation("sapphire_block", <bluepower:sapphire_block>);
+
+//Amber
+mods.chisel.Groups.addVariation("amber", <BiomesOPlenty:gemOre:15>);
+
+//TinCo
+//Seared Stone
+mods.chisel.Groups.addGroup("seared_stone"); 
+mods.chisel.Groups.addVariation("seared_stone", <TConstruct:Smeltery:2>);
+mods.chisel.Groups.addVariation("seared_stone", <TConstruct:Smeltery:4>);
+mods.chisel.Groups.addVariation("seared_stone", <TConstruct:Smeltery:5>);
+mods.chisel.Groups.addVariation("seared_stone", <TConstruct:Smeltery:6>);
+mods.chisel.Groups.addVariation("seared_stone", <TConstruct:Smeltery:7>);
+mods.chisel.Groups.addVariation("seared_stone", <TConstruct:Smeltery:8>);
+mods.chisel.Groups.addVariation("seared_stone", <TConstruct:Smeltery:9>);
+mods.chisel.Groups.addVariation("seared_stone", <TConstruct:Smeltery:10>);
+mods.chisel.Groups.addVariation("seared_stone", <TConstruct:Smeltery:11>);
+
+//Seared Slab
+mods.chisel.Groups.addGroup("seared_slab"); 
+mods.chisel.Groups.addVariation("seared_slab", <TConstruct:SearedSlab:0>);
+mods.chisel.Groups.addVariation("seared_slab", <TConstruct:SearedSlab:1>);
+mods.chisel.Groups.addVariation("seared_slab", <TConstruct:SearedSlab:2>);
+mods.chisel.Groups.addVariation("seared_slab", <TConstruct:SearedSlab:3>);
+mods.chisel.Groups.addVariation("seared_slab", <TConstruct:SearedSlab:4>);
+mods.chisel.Groups.addVariation("seared_slab", <TConstruct:SearedSlab:5>);
+mods.chisel.Groups.addVariation("seared_slab", <TConstruct:SearedSlab:6>);
+mods.chisel.Groups.addVariation("seared_slab", <TConstruct:SearedSlab:7>);
+
+//Nether Seared Stone
+mods.chisel.Groups.addGroup("nether_seared_stone"); 
+mods.chisel.Groups.addVariation("nether_seared_stone", <TConstruct:SmelteryNether:2>);
+mods.chisel.Groups.addVariation("nether_seared_stone", <TConstruct:SmelteryNether:4>);
+mods.chisel.Groups.addVariation("nether_seared_stone", <TConstruct:SmelteryNether:5>);
+mods.chisel.Groups.addVariation("nether_seared_stone", <TConstruct:SmelteryNether:6>);
+mods.chisel.Groups.addVariation("nether_seared_stone", <TConstruct:SmelteryNether:7>);
+mods.chisel.Groups.addVariation("nether_seared_stone", <TConstruct:SmelteryNether:8>);
+mods.chisel.Groups.addVariation("nether_seared_stone", <TConstruct:SmelteryNether:9>);
+mods.chisel.Groups.addVariation("nether_seared_stone", <TConstruct:SmelteryNether:10>);
+mods.chisel.Groups.addVariation("nether_seared_stone", <TConstruct:SmelteryNether:11>);
+
+//Rough Brownstone
+mods.chisel.Groups.addGroup("rough_brownstone"); 
+mods.chisel.Groups.addVariation("rough_brownstone", <TConstruct:SpeedBlock:0>);
+mods.chisel.Groups.addVariation("rough_brownstone", <TConstruct:SpeedBlock:1>);
+
+//Rough Brownstone Slab
+mods.chisel.Groups.addGroup("rough_brownstone_slab"); 
+mods.chisel.Groups.addVariation("rough_brownstone_slab", <TConstruct:SpeedSlab:0>);
+mods.chisel.Groups.addVariation("rough_brownstone_slab", <TConstruct:SpeedSlab:1>);
+
+//Brownstone
+mods.chisel.Groups.addGroup("brownstone");
+mods.chisel.Groups.addVariation("brownstone", <TConstruct:SpeedBlock:2>);
+mods.chisel.Groups.addVariation("brownstone", <TConstruct:SpeedBlock:3>);
+mods.chisel.Groups.addVariation("brownstone", <TConstruct:SpeedBlock:4>);
+mods.chisel.Groups.addVariation("brownstone", <TConstruct:SpeedBlock:5>);
+mods.chisel.Groups.addVariation("brownstone", <TConstruct:SpeedBlock:6>);
+
+//Brownstone Slab
+mods.chisel.Groups.addGroup("brownstone_slab");
+mods.chisel.Groups.addVariation("brownstone_slab", <TConstruct:SpeedSlab:2>);
+mods.chisel.Groups.addVariation("brownstone_slab", <TConstruct:SpeedSlab:3>);
+mods.chisel.Groups.addVariation("brownstone_slab", <TConstruct:SpeedSlab:4>);
+mods.chisel.Groups.addVariation("brownstone_slab", <TConstruct:SpeedSlab:5>);
+mods.chisel.Groups.addVariation("brownstone_slab", <TConstruct:SpeedSlab:6>);

--- a/scripts/Compat.zs
+++ b/scripts/Compat.zs
@@ -6,7 +6,7 @@
 <ore:silicon>.mirror(<ore:itemSilicon>);
 
 // Endermen head exchange
-// recipes.addShapeless(<EnderIO:blockEndermanSkull>, [<IguanaTweaksTConstruct:skullItem>]);
+recipes.addShapeless(<EnderIO:blockEndermanSkull>, [<IguanaTweaksTConstruct:skullItem>.noReturn()]);
 recipes.addShapeless(<IguanaTweaksTConstruct:skullItem>, [<HardcoreEnderExpansion:enderman_head>]);
 recipes.addShapeless(<HardcoreEnderExpansion:enderman_head>, [<EnderIO:blockEndermanSkull>]);
 

--- a/scripts/GalaxySpace.zs
+++ b/scripts/GalaxySpace.zs
@@ -1,0 +1,63 @@
+/*Galaxy Space
+   Tweaks and Alterations*/
+
+//Cobalt and Cobaltum Unification
+<ore:ingotCobaltum>.addAll(<ore:ingotCobalt>);
+<ore:oreCobaltum>.addAll(<ore:oreCobalt>);
+<ore:blockCobaltum>.addAll(<ore:blockCobalt>);
+
+<ore:ingotCobalt>.mirror(<ore:ingotCobaltum>);
+<ore:oreCobalt>.mirror(<ore:oreCobaltum>);
+<ore:blockCobalt>.mirror(<ore:blockCobaltum>);
+//Cobaltum ore processing
+mods.mekanism.Enrichment.addRecipe(<GalaxySpace:phoboscobaltumore>, <TConstruct:materials:39> * 2);
+mods.mekanism.Purification.addRecipe(<GalaxySpace:phoboscobaltumore>, <gas:oxygen>, <aobd:clumpCobalt> * 3);
+mods.mekanism.chemical.Injection.addRecipe(<GalaxySpace:phoboscobaltumore>, <gas:hydrogenchloride>, <aobd:shardCobalt> * 4);
+mods.mekanism.chemical.Dissolution.addRecipe(<GalaxySpace:phoboscobaltumore>, <gas:Cobalt>);
+
+mods.tconstruct.Smeltery.addMelting(<GalaxySpace:phoboscobaltumore>, <liquid:cobalt.molten> * 288, 650, <GalaxySpace:phoboscobaltumore>);
+mods.tconstruct.Smeltery.addMelting(<GalaxySpace:item.CobaltumIngot>, <liquid:cobalt.molten> * 144, 600, <TConstruct:MetalBlock>);
+
+mods.thaumcraft.Crucible.addRecipe("PUREORE", <aobd:clusterCobalt>, <GalaxySpace:phoboscobaltumore>, "metallum 1, ordo 1");
+
+mods.railcraft.RockCrusher.addRecipe(<GalaxySpace:phoboscobaltumore>, false, false, [<aobd:crushedCobalt> * 2], [1]);
+
+//Tungsten and Wolframium Unification
+<ore:ingotWolframium>.addAll(<ore:ingotTungsten>);
+<ore:oreWolframium>.addAll(<ore:oreTungsten>);
+<ore:blockWolframium>.addAll(<ore:blockTungsten>);
+
+<ore:ingotTungsten>.mirror(<ore:ingotWolframium>);
+<ore:oreTungsten>.mirror(<ore:oreWolframium>);
+<ore:blockTungsten>.mirror(<ore:blockWolframium>);
+//Wolframium ore processing
+mods.mekanism.Enrichment.addRecipe(<GalaxySpace:proteuswolframiumore>, <aobd:dustTungsten> * 2);
+mods.mekanism.Purification.addRecipe(<GalaxySpace:proteuswolframiumore>, <gas:oxygen>, <aobd:clumpTungsten> * 3);
+mods.mekanism.chemical.Injection.addRecipe(<GalaxySpace:proteuswolframiumore>, <gas:hydrogenchloride>, <aobd:shardTungsten> * 4);
+mods.mekanism.chemical.Dissolution.addRecipe(<GalaxySpace:proteuswolframiumore>, <gas:Tungsten>);
+
+mods.tconstruct.Smeltery.addMelting(<GalaxySpace:proteuswolframiumore>, <liquid:tungsten> * 288, 1200, <GalaxySpace:proteuswolframiumore>);
+mods.tconstruct.Smeltery.addMelting(<GalaxySpace:item.WolframiumIngot>, <liquid:tungsten> * 144, 1200, <bluepower:tungsten_block>);
+
+mods.thaumcraft.Crucible.addRecipe("PUREORE", <aobd:clusterTungsten>, <GalaxySpace:proteuswolframiumore>, "metallum 1, ordo 1");
+
+mods.railcraft.RockCrusher.addRecipe(<GalaxySpace:proteuswolframiumore>, false, false, [<aobd:crushedTungsten> * 2], [1]);
+
+//Lead Armor Crafting (Using wrought iron as a cheap early game material) 
+recipes.remove(<GalaxySpace:item.lead_leg>);
+recipes.remove(<GalaxySpace:item.lead_boots>);
+recipes.remove(<GalaxySpace:item.lead_plate>);
+recipes.remove(<GalaxySpace:item.lead_helmet>);
+
+recipes.addShaped(<GalaxySpace:item.lead_boots>, [[<ore:ingotWroughtIron>, null, <ore:ingotWroughtIron>], [<ore:ingotLead>, null, <ore:ingotLead>]]);
+recipes.addShaped(<GalaxySpace:item.lead_leg>, [[<ore:ingotWroughtIron>, <ore:ingotLead>, <ore:ingotWroughtIron>], [<ore:ingotLead>, null, <ore:ingotLead>], [<ore:ingotLead>, null, <ore:ingotLead>]]);
+recipes.addShaped(<GalaxySpace:item.lead_plate>, [[<ore:ingotWroughtIron>, null, <ore:ingotWroughtIron>], [<ore:ingotLead>, <ore:ingotLead>, <ore:ingotLead>], [<ore:ingotLead>, <ore:ingotLead>, <ore:ingotLead>]]);
+recipes.addShaped(<GalaxySpace:item.lead_helmet>, [[<ore:ingotLead>, <ore:ingotLead>, <ore:ingotLead>], [<ore:ingotWroughtIron>, null, <ore:ingotWroughtIron>]]);
+
+//Schematics Recipes
+recipes.addShaped(<GalaxySpace:item.SchematicTier8>, [[<GalaxySpace:item.HeavyDutyPlate7>, <GalaxySpace:item.HeavyDutyPlate8>, <GalaxySpace:item.HeavyDutyPlate7>], [<GalaxySpace:item.HeavyDutyPlate7>, <GalaxySpace:item.HeavyDutyPlate8>, <GalaxySpace:item.HeavyDutyPlate7>], [<GalaxySpace:item.HeavyDutyPlate8>, <GalaxySpace:item.HeavyDutyPlate6>, <GalaxySpace:item.HeavyDutyPlate8>]]);
+recipes.addShaped(<GalaxySpace:item.SchematicTier7>, [[<GalaxySpace:item.HeavyDutyPlate6>, <GalaxySpace:item.HeavyDutyPlate7>, <GalaxySpace:item.HeavyDutyPlate6>], [<GalaxySpace:item.HeavyDutyPlate6>, <GalaxySpace:item.HeavyDutyPlate7>, <GalaxySpace:item.HeavyDutyPlate6>], [<GalaxySpace:item.HeavyDutyPlate7>, <GalaxySpace:item.HeavyDutyPlate5>, <GalaxySpace:item.HeavyDutyPlate7>]]);
+recipes.addShaped(<GalaxySpace:item.SchematicTier6>, [[<GalaxySpace:item.HeavyDutyPlate5>, <GalaxySpace:item.HeavyDutyPlate6>, <GalaxySpace:item.HeavyDutyPlate5>], [<GalaxySpace:item.HeavyDutyPlate5>, <GalaxySpace:item.HeavyDutyPlate6>, <GalaxySpace:item.HeavyDutyPlate5>], [<GalaxySpace:item.HeavyDutyPlate6>, <GalaxySpace:item.HeavyDutyPlate4>, <GalaxySpace:item.HeavyDutyPlate6>]]);
+recipes.addShaped(<GalaxySpace:item.SchematicTier5>, [[<GalaxySpace:item.HeavyDutyPlate4>, <GalaxySpace:item.HeavyDutyPlate5>, <GalaxySpace:item.HeavyDutyPlate4>], [<GalaxySpace:item.HeavyDutyPlate4>, <GalaxySpace:item.HeavyDutyPlate5>, <GalaxySpace:item.HeavyDutyPlate4>], [<GalaxySpace:item.HeavyDutyPlate5>, <GalaxySpace:item.HeavyDutyPlate4>, <GalaxySpace:item.HeavyDutyPlate5>]]);
+recipes.addShaped(<GalaxySpace:item.SchematicTier4>, [[<GalacticraftMars:item.itemBasicAsteroids>, <GalaxySpace:item.HeavyDutyPlate4>, <GalacticraftMars:item.itemBasicAsteroids>], [<GalacticraftMars:item.itemBasicAsteroids>, <GalaxySpace:item.HeavyDutyPlate4>, <GalacticraftMars:item.itemBasicAsteroids>], [<GalaxySpace:item.HeavyDutyPlate4>, <GalacticraftMars:item.itemBasicAsteroids>, <GalaxySpace:item.HeavyDutyPlate4>]]);
+

--- a/scripts/PlantMegaPack.zs
+++ b/scripts/PlantMegaPack.zs
@@ -1,0 +1,60 @@
+/* Plant Mega Pack 
+     Tweaks and Alterations*/
+
+//Oredicting the Berries
+<ore:foodBerries>.add(<plantmegapack:berriesBeauty>);
+<ore:foodBerries>.add(<plantmegapack:berriesBlack>);
+<ore:foodBerries>.add(<plantmegapack:berriesBlue>);
+<ore:foodBerries>.add(<plantmegapack:berriesElder>);
+<ore:foodBerries>.add(<plantmegapack:berriesGoose>);
+<ore:foodBerries>.add(<plantmegapack:berriesHarlequinMistletoe>);
+<ore:foodBerries>.add(<plantmegapack:berriesHuckle>);
+<ore:foodBerries>.add(<plantmegapack:berriesOrange>);
+<ore:foodBerries>.add(<plantmegapack:berriesSnow>);
+<ore:foodBerries>.add(<plantmegapack:berriesStraw>);
+
+//Jelly Production
+//Oredicting
+<ore:foodJelly>.add(<plantmegapack:foodJelly>);
+
+//Crafting with oredicted Berries and PricklyPear
+recipes.remove(<plantmegapack:foodJelly>);
+recipes.addShaped(<plantmegapack:foodJelly>, [[<plantmegapack:foodPricklyPearFruit>, <plantmegapack:foodPricklyPearFruit>, <plantmegapack:foodPricklyPearFruit>], [null, <minecraft:sugar>, null], [null, <minecraft:glass_bottle>, null]]);
+recipes.addShaped(<plantmegapack:foodJelly>, [[<ore:foodBerries>, <ore:foodBerries>, <ore:foodBerries>], [null, <minecraft:sugar>, null], [null, <minecraft:glass_bottle>, null]]);
+
+//Crafting Berry Bowl with oredicted Berries
+recipes.remove(<plantmegapack:foodBerrybowl>);
+recipes.addShapeless(<plantmegapack:foodBerrybowl>, [<minecraft:bowl>, <ore:foodBerries>, <ore:foodBerries>]);
+
+//Crafting Berry Powder with oredicted Berries
+recipes.removeShaped(<plantmegapack:powderBerry>);
+recipes.addShaped(<plantmegapack:powderBerry>, [[<ore:foodBerries>, <minecraft:string>, <ore:foodBerries>], [<ore:foodBerries>, <minecraft:leather>, <ore:foodBerries>], [<ore:foodBerries>, <ore:foodBerries>, <ore:foodBerries>]]);
+
+//Crafting Pastries with Berries from other mods
+recipes.addShaped(<plantmegapack:foodElderberrySorbet>, [[null, <minecraft:sugar>, null], [<ExtraTrees:food:34>, <ore:bucketMilk>, <ExtraTrees:food:34>], [null, <minecraft:bowl>, null]]);
+
+recipes.addShaped(<plantmegapack:foodBlackberryDanish> * 2, [[null, null, null], [<ExtraTrees:food:43>, <minecraft:sugar>, <ExtraTrees:food:43>], [<minecraft:wheat>, <minecraft:egg>, <minecraft:wheat>]]);
+
+recipes.addShapeless(<plantmegapack:foodBlueberryMuffin> * 6, [<ExtraTrees:food:45>, <ExtraTrees:food:45>, <minecraft:bread>]);
+recipes.addShapeless(<plantmegapack:foodBlueberryMuffin> * 6, [<ExtraTrees:food:45>, <ExtraTrees:food:45>, <plantmegapack:foodCornBread>]);
+
+recipes.addShaped(<plantmegapack:foodGooseberryCobbler> * 2, [[null, null, null], [<ExtraTrees:food:48>, <minecraft:sugar>, <ExtraTrees:food:48>], [<minecraft:wheat>, <minecraft:egg>, <minecraft:wheat>]]);
+
+recipes.removeShapeless(<plantmegapack:foodSandwichPBJ>);
+recipes.addShapeless(<plantmegapack:foodSandwichPBJ>, [<minecraft:bread>, <plantmegapack:foodPeanutButter>, <ore:foodJelly>]);
+recipes.addShapeless(<plantmegapack:foodSandwichPBJ>, [<plantmegapack:foodCornBread>, <plantmegapack:foodPeanutButter>, <ore:foodJelly>]);
+
+//Crafting Smoothies with Berries from other mods
+recipes.addShaped(<plantmegapack:foodBlackberryTumbler>, [[<ExtraTrees:food:43>, <ExtraTrees:food:43>, <ExtraTrees:food:43>], [<minecraft:sugar>, <ore:bucketMilk>, <minecraft:sugar>], [null, <minecraft:glass_bottle>, null]]);
+
+recipes.addShaped(<plantmegapack:foodBlueberrySlushie>,  [[<ExtraTrees:food:45>, <ExtraTrees:food:45>, <ExtraTrees:food:45>], [<minecraft:sugar>, <ore:bucketMilk>, <minecraft:sugar>], [null, <minecraft:glass_bottle>, null]]);
+
+recipes.addShaped(<plantmegapack:foodElderberrySpritzer>,  [[<ExtraTrees:food:34>, <ExtraTrees:food:34>, <ExtraTrees:food:34>], [<minecraft:sugar>, <ore:bucketMilk>, <minecraft:sugar>], [null, <minecraft:glass_bottle>, null]]);
+
+recipes.addShaped(<plantmegapack:foodGooseberryShake>,  [[<ExtraTrees:food:48>, <ExtraTrees:food:48>, <ExtraTrees:food:48>], [<minecraft:sugar>, <ore:bucketMilk>, <minecraft:sugar>], [null, <minecraft:glass_bottle>, null]]);
+
+
+//Crafting Beet Soup with etFuturum Beet
+recipes.addShapeless(<plantmegapack:foodBeetSoup>, [<minecraft:bowl>, <etfuturum:beetroot>, <etfuturum:beetroot>]);
+
+

--- a/scripts/Tconstruct.zs
+++ b/scripts/Tconstruct.zs
@@ -16,6 +16,10 @@ recipes.addShaped(<TConstruct:knapsack>, [[<minecraft:leather>, <minecraft:leath
 recipes.remove(<minecraft:light_weighted_pressure_plate>);
 recipes.addShaped(<minecraft:light_weighted_pressure_plate>, [[<ore:ingotGold>, <ore:ingotGold>, null], [null, null, null], [null, null, null]]);
 
+//Adv. Drawbridge crafting with oredict
+recipes.removeShapeless(<TMechworks:RedstoneMachine:3>);
+recipes.addShapeless(<TMechworks:RedstoneMachine:3>, [<ore:ingotCobalt>, <ore:ingotCobalt>, <ore:ingotCobalt>,  <ore:ingotArdite>, <ore:ingotArdite>, <ore:ingotArdite>, <ore:blockRedstone>, <TMechworks:RedstoneMachine>]); 
+
 // Smeltery removals
 mods.tconstruct.Smeltery.removeMelting(<minecraft:minecart>);
 

--- a/scripts/Thaumcraft.zs
+++ b/scripts/Thaumcraft.zs
@@ -40,3 +40,8 @@ game.setLocalization("en_US", "botania.page.tcIntegration8", "&o99 problems but 
 
 /* Vanilla */
 recipes.addShapeless(<Thaumcraft:ItemResource:9>, [<minecraft:book>, <Thaumcraft:ItemShard:*>, <Thaumcraft:ItemShard:*>]);
+
+//Abmber Oredict Crafting
+recipes.remove(<Thaumcraft:blockCosmeticOpaque:0>);
+recipes.addShaped(<Thaumcraft:blockCosmeticOpaque:0>, [[<ore:gemAmber>, <ore:gemAmber>], [<ore:gemAmber>, <ore:gemAmber>]]);
+

--- a/scripts/Tropicraft.zs
+++ b/scripts/Tropicraft.zs
@@ -1,6 +1,10 @@
 /* Tropicraft
    Tweaks and Alterations */
 
+//Oredicting Oranges
+<ore:cropOrange>.add(<tropicraft:orange>);
+
+//Oredicting Bamboo from other mods
 <ore:bamboo>.add(<plantmegapack:bambooAsper>);
 <ore:bamboo>.add(<plantmegapack:bambooFargesiaRobusta>);
 <ore:bamboo>.add(<plantmegapack:bambooGiantTimber>);

--- a/scripts/TwilightForest.zs
+++ b/scripts/TwilightForest.zs
@@ -3,3 +3,17 @@
 
 // Uncrafting Table
 recipes.remove(<TwilightForest:tile.TFUncraftingTable>);
+
+//Moss Patch Crafting
+recipes.addShaped(<TwilightForest:tile.TFPlant:3> * 3, [[<TConstruct:materials:6>, <TConstruct:materials:6>]]);
+
+//Lilly Crafting
+recipes.addShapeless(<TwilightForest:tile.HugeLilyPad>, [<gendustry:MutagenBucket>, <ore:fertilizerRich>, <TwilightForest:item.transformPowder>, <minecraft:waterlily>]);
+recipes.addShapeless(<minecraft:waterlily>, [<gendustry:MutagenBucket>, <Botany:misc:7>, <TwilightForest:tile.HugeLilyPad>]);
+recipes.addShapeless(<TwilightForest:tile.HugeWaterLily>, [<gendustry:MutagenBucket>, <Botania:petal:*>, <TwilightForest:tile.HugeLilyPad>]);
+
+//Lilly replication with Photo Insolator
+mods.thermalexpansion.Insolator.addRecipe(7200, <ThermalExpansion:material:516>, <TwilightForest:tile.HugeLilyPad>, <TwilightForest:tile.HugeLilyPad> * 2);
+mods.thermalexpansion.Insolator.addRecipe(9600, <ThermalExpansion:material:517>, <TwilightForest:tile.HugeLilyPad>, <TwilightForest:tile.HugeLilyPad> * 4);
+mods.thermalexpansion.Insolator.addRecipe(7200, <ThermalExpansion:material:516>, <TwilightForest:tile.HugeWaterLily>, <TwilightForest:tile.HugeWaterLily> * 2);
+mods.thermalexpansion.Insolator.addRecipe(9600, <ThermalExpansion:material:517>, <TwilightForest:tile.HugeWaterLily>, <TwilightForest:tile.HugeWaterLily> * 4);

--- a/scripts/Witchery.zs
+++ b/scripts/Witchery.zs
@@ -1,0 +1,7 @@
+/* Witchery
+   Tweaks and Alterations */
+
+//Crafting Ice fence gates, fences, and stockades 
+recipes.addShaped(<witchery:icefencegate>, [[<witchery:icefence>, <ore:blockIce>, <witchery:icefence>]]);
+recipes.addShaped(<witchery:icefence> * 4, [[<ore:blockIce>, <ore:blockIce>, <ore:blockIce>], [<ore:blockIce>, null, <ore:blockIce>]]);
+recipes.addShaped(<witchery:icestockade> * 9, [[null, <ore:blockIce>, null], [<ore:blockIce>, <witchery:ingredient:31>, <ore:blockIce>], [<ore:blockIce>, <ore:blockIce>, <ore:blockIce>]]);

--- a/scripts/etFuturum.zs
+++ b/scripts/etFuturum.zs
@@ -1,0 +1,5 @@
+/*Et Futurum
+ tweaks and additions*/
+
+recipes.addShaped(<etfuturum:beetroot_soup>, [[<plantmegapack:foodBeet>, <plantmegapack:foodBeet>, <plantmegapack:foodBeet>], [<plantmegapack:foodBeet>, <plantmegapack:foodBeet>, <plantmegapack:foodBeet>], [null, <minecraft:bowl>, null]]);
+<etfuturum:beetroot_soup>.addTooltip(format.darkGray("A stronger recipe"));

--- a/scripts/thermal.zs
+++ b/scripts/thermal.zs
@@ -6,3 +6,9 @@ recipes.addShapeless(<ThermalDynamics:ThermalDynamics_32:6>.withTag({DenseType: 
 recipes.addShapeless(<ThermalDynamics:ThermalDynamics_32:6>.withTag({DenseType: 2 as byte}), [<ThermalDynamics:ThermalDynamics_32:6>, <ore:dustSilver>]);
 recipes.addShapeless(<ThermalDynamics:ThermalDynamics_32:7>.withTag({DenseType: 1 as byte}), [<ThermalDynamics:ThermalDynamics_32:7>, <ore:dustLead>]);
 recipes.addShapeless(<ThermalDynamics:ThermalDynamics_32:7>.withTag({DenseType: 2 as byte}), [<ThermalDynamics:ThermalDynamics_32:7>, <ore:dustSilver>]);
+
+/*Thermal Expansion*/
+//Compressed Sawdust oredict crafting
+recipes.remove(<ThermalExpansion:material:513>);
+recipes.addShaped(<ThermalExpansion:material:513>, [[<ore:pulpWood>, <ore:pulpWood>, <ore:pulpWood>], [<ore:pulpWood>, null, <ore:pulpWood>], [<ore:pulpWood>, <ore:pulpWood>, <ore:pulpWood>]]);
+


### PR DESCRIPTION
Some Changes, please review them at your leisure.

aobd.cfg
Disabled Wofranium and Cobaltium integration. (Unified with Tungsten and Cobalt)

en_US.lang
fixed Sparkpowder's Localisation

Binnie.zs
Add berries to oredict
Wood pulp now crafted using oredict

BOP.zs
Add berries to oredict
Crafting recipes for poison jars, dart blowers, darts, fruit salads,lillies
Amber Recipe removed (Can be now be chiseled from TC Amber)

Chisel.zs
Added categories for rubies, sapphires, and tiCo blocks
Added ice stair and Amber Block variations

Compat.zs
Enderman exchange should now be working

Tconstruct.zs
Adv. Drawbrige recipe now uses the oredict

Thaumcraft.zs
Amber Block recipe now uses the oredict

thermal.zs
Compressed sawdust now uses the oredict

Tropicraft.zs
Oranges added to oredict

TwiligtForest.zs
Moss Patch, Lillies now craftable

Added:

Aether.zs
Berries, Oranges added to oredict
Aether food now can be crafted with other mods
Plant Mega pack food can now be crafted with Aether's materials

etFuturum.zs
Beet Soup can now be crafted using Plant Mega Pack's beet

GalaxySpace.zs
Cobaltum unified with Cobalt
Wolframium unified with Tungsten
Alt recipe for lead armor
NASA schematics have recipies

PlantMegaPack.zs
Foodstuff can now be crafted using other mods

Witchery.zs
Ice fence gates, fences, and stockades can now be crafted