### PR TITLE
[1.7.10] Unify Diamond Nuggets & Fix crafting OpenComputers Diamond Chips using diamond nuggets

### DIFF
--- a/modpack/default/OpenComputers.zs
+++ b/modpack/default/OpenComputers.zs
@@ -1,0 +1,8 @@
+// Make Diamond Chips craftable using diamond nuggets instead of full diamonds, conflicting recipe fix.
+
+val diamondChip = <OpenComputers:item:111>;
+val diamondNugget = <Ore:nuggetDiamond>;
+
+recipes.remove(diamondChip);
+
+recipes.addShapeless(diamondChip * 2, [diamondNugget, diamondNugget, diamondNugget]);

--- a/modpack/default/Vanilla.zs
+++ b/modpack/default/Vanilla.zs
@@ -22,8 +22,8 @@ val shard2 = <MagicBees:beeNugget:5>;
 val shard3 = <enhancedportals:nuggetDiamond>;
 val shard4 = <Translocator:diamondNugget>;
 
-diamond.add(shard1);
-diamond.add(shard2);
+diamondNugget.add(shard1);
+diamondNugget.add(shard2);
 
 // Add Ore Dictionary Recipe to craft Diamonds using Diamond Nuggets.
 

--- a/modpack/default/Vanilla.zs
+++ b/modpack/default/Vanilla.zs
@@ -13,3 +13,18 @@ recipes.addShapeless(<minecraft:hardened_clay> * 8, [<minecraft:water_bucket>.tr
 
 // Gray
 recipes.addShapeless(<minecraft:dye:8>, [<ore:dyeBlack>, <ore:dyeWhite>]);
+
+// Unify Diamond Nuggets
+
+val diamondNugget = <ore:nuggetDiamond>;
+val shard1 = <ExtraBees:misc:1>;
+val shard2 = <MagicBees:beeNugget:5>;
+val shard3 = <enhancedportals:nuggetDiamond>;
+val shard4 = <Translocator:diamondNugget>;
+
+diamond.add(shard1);
+diamond.add(shard2);
+
+// Add Ore Dictionary Recipe to craft Diamonds using Diamond Nuggets.
+
+recipes.addShapeless(<minecraft:diamond>, [diamondNugget, diamondNugget, diamondNugget, diamondNugget, diamondNugget, diamondNugget, diamondNugget, diamondNugget, diamondNugget]);

--- a/scripts/OpenComputers.zs
+++ b/scripts/OpenComputers.zs
@@ -1,0 +1,8 @@
+// Make Diamond Chips craftable using diamond nuggets instead of full diamonds, conflicting recipe fix.
+
+val diamondChip = <OpenComputers:item:111>;
+val diamondNugget = <Ore:nuggetDiamond>;
+
+recipes.remove(diamondChip);
+
+recipes.addShapeless(diamondChip * 2, [diamondNugget, diamondNugget, diamondNugget]);

--- a/scripts/Vanilla.zs
+++ b/scripts/Vanilla.zs
@@ -22,8 +22,8 @@ val shard2 = <MagicBees:beeNugget:5>;
 val shard3 = <enhancedportals:nuggetDiamond>;
 val shard4 = <Translocator:diamondNugget>;
 
-diamond.add(shard1);
-diamond.add(shard2);
+diamondNugget.add(shard1);
+diamondNugget.add(shard2);
 
 // Add Ore Dictionary Recipe to craft Diamonds using Diamond Nuggets.
 

--- a/scripts/Vanilla.zs
+++ b/scripts/Vanilla.zs
@@ -13,3 +13,18 @@ recipes.addShapeless(<minecraft:hardened_clay> * 8, [<minecraft:water_bucket>.tr
 
 // Gray
 recipes.addShapeless(<minecraft:dye:8>, [<ore:dyeBlack>, <ore:dyeWhite>]);
+
+// Unify Diamond Nuggets
+
+val diamondNugget = <ore:nuggetDiamond>;
+val shard1 = <ExtraBees:misc:1>;
+val shard2 = <MagicBees:beeNugget:5>;
+val shard3 = <enhancedportals:nuggetDiamond>;
+val shard4 = <Translocator:diamondNugget>;
+
+diamond.add(shard1);
+diamond.add(shard2);
+
+// Add Ore Dictionary Recipe to craft Diamonds using Diamond Nuggets.
+
+recipes.addShapeless(<minecraft:diamond>, [diamondNugget, diamondNugget, diamondNugget, diamondNugget, diamondNugget, diamondNugget, diamondNugget, diamondNugget, diamondNugget]);


### PR DESCRIPTION
Fixes a recipe conflict. Included script changes apply to both servers & single player because of FTB Utils odd placement for script files.

Previously one was unable to craft Diamond Chips from OpenComputers because the recipe to craft 9 diamond nuggets took precedence. Now the recipe calls for 3 Diamond Nuggets to craft 2 Diamond Chips instead of 1 Diamond for 6 Diamond Chips. I also Oredicted and added a new shapeless recipe for the various diamond nuggets into a single diamond so you can mix-n match the various diamond nuggets to craft full diamonds once again.
